### PR TITLE
Allow connections to OVS over a unix domain socket.

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,23 +32,9 @@ var connections map[*rpc2.Client]*OvsdbClient
 
 const DEFAULT_ADDR = "127.0.0.1"
 const DEFAULT_PORT = 6640
+const DEFAULT_SOCK = "/var/run/openvswitch/db.sock"
 
-func Connect(ipAddr string, port int) (*OvsdbClient, error) {
-	if ipAddr == "" {
-		ipAddr = DEFAULT_ADDR
-	}
-
-	if port <= 0 {
-		port = DEFAULT_PORT
-	}
-
-	target := fmt.Sprintf("%s:%d", ipAddr, port)
-	conn, err := net.Dial("tcp", target)
-
-	if err != nil {
-		return nil, err
-	}
-
+func configureConnection(conn net.Conn) (*OvsdbClient, error) {
 	c := rpc2.NewClientWithCodec(jsonrpc.NewJSONCodec(conn))
 	c.Handle("echo", echo)
 	c.Handle("update", update)
@@ -70,6 +56,37 @@ func Connect(ipAddr string, port int) (*OvsdbClient, error) {
 		}
 	}
 	return ovs, nil
+}
+
+func ConnectUnix(socketPath string) (*OvsdbClient, error) {
+	if socketPath == "" {
+		socketPath = DEFAULT_SOCK
+	}
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return configureConnection(conn)
+}
+
+func Connect(ipAddr string, port int) (*OvsdbClient, error) {
+	if ipAddr == "" {
+		ipAddr = DEFAULT_ADDR
+	}
+
+	if port <= 0 {
+		port = DEFAULT_PORT
+	}
+
+	target := fmt.Sprintf("%s:%d", ipAddr, port)
+	conn, err := net.Dial("tcp", target)
+	if err != nil {
+		return nil, err
+	}
+
+	return configureConnection(conn)
 }
 
 func (ovs *OvsdbClient) Register(handler NotificationHandler) {

--- a/example/play_with_ovs.go
+++ b/example/play_with_ovs.go
@@ -132,6 +132,9 @@ func main() {
 	// If you prefer to connect to OVS in a specific location :
 	// ovs, err := libovsdb.Connect("192.168.56.101", 6640)
 
+	// If you prefer to connect over a Unix socket:
+	// ovs, err := libovsdb.ConnectUnix("")
+
 	if err != nil {
 		fmt.Println("Unable to Connect ", err)
 		os.Exit(1)


### PR DESCRIPTION
@mapuri @jainvipin

This is the patch I submitted to libovsdb: https://github.com/socketplane/libovsdb/pull/35

Perhaps we can make use of it separately.
